### PR TITLE
CI: add pytest-cov for coverage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.110.0
 uvicorn==0.29.0
 pytest==8.1.1
 httpx==0.27.0
+pytest-cov==4.1.0


### PR DESCRIPTION
Fix failing quality gate by installing pytest-cov so --cov flags are recognized.