### PR TITLE
TASK-009: Observability scaffold and spans

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 
 from .config import Settings
 from .model_loader import ModelLoader
+from .obs import Observability
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -15,10 +16,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         model_version=settings.model_version,
     )
     app.state.model_loader = loader
+    app.state.obs = Observability(settings)
 
     from .routes import get_health_router, get_router
 
-    app.include_router(get_router(app, settings, loader))
+    app.include_router(get_router(app, settings, loader, app.state.obs))
     app.include_router(get_health_router(settings, loader))
     return app
 

--- a/app/obs.py
+++ b/app/obs.py
@@ -1,0 +1,46 @@
+from contextlib import contextmanager
+from typing import Callable, Dict, Optional
+
+from opentelemetry import metrics, trace
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from .config import Settings
+
+
+class Observability:
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self._tracer_provider = TracerProvider()
+        self._meter_provider = MeterProvider()
+        trace.set_tracer_provider(self._tracer_provider)
+        metrics.set_meter_provider(self._meter_provider)
+        self.tracer = trace.get_tracer(__name__)
+        self.meter = metrics.get_meter(__name__)
+
+        self.request_counter = self.meter.create_counter(
+            name="requests_total",
+            description="Total requests",
+        )
+        self.latency_hist = self.meter.create_histogram(
+            name="request_latency_ms",
+            description="Request latency in ms",
+            unit="ms",
+        )
+        self.inference_latency = self.meter.create_histogram(
+            name="inference_latency_ms",
+            description="Inference latency in ms",
+            unit="ms",
+        )
+
+    @contextmanager
+    def span(self, name: str, attributes: Optional[Dict] = None):
+        span = self.tracer.start_span(name=name)
+        if attributes:
+            for k, v in attributes.items():
+                span.set_attribute(k, v)
+        try:
+            yield span
+        finally:
+            span.end()

--- a/app/routes.py
+++ b/app/routes.py
@@ -7,6 +7,7 @@ from .config import Settings
 from .errors import raise_http
 from .health import readiness_payload
 from .model_loader import ModelLoader
+from .obs import Observability
 from .rate_limit import SimpleRateLimiter
 from .schemas import (
     AgentMove,
@@ -30,7 +31,7 @@ def _render_hits(board_size: int, hits: dict) -> List[List[str]]:
     return board
 
 
-def get_router(app: FastAPI, settings: Settings, loader: ModelLoader) -> APIRouter:
+def get_router(app: FastAPI, settings: Settings, loader: ModelLoader, obs: Observability) -> APIRouter:
     router = APIRouter(prefix="/api", tags=["gameplay"])
     session_store = engine.InMemorySessionStore(settings.max_active_games)
     agent_adapter = agent.AgentAdapter(deterministic=settings.deterministic_mode)
@@ -50,12 +51,13 @@ def get_router(app: FastAPI, settings: Settings, loader: ModelLoader) -> APIRout
             raise_http("rate_limited", {"retry_after": 5})
         if not loader.ready:
             raise_http("model_not_ready")
-        try:
-            session = session_store.create(
-                board_size=settings.board_size, deterministic_seed=settings.deterministic_mode and 0 or None
-            )
-        except engine.InvalidMove:
-            raise_http("capacity_exceeded", {"retry_after": 5})
+        with obs.span("game.start"):
+            try:
+                session = session_store.create(
+                    board_size=settings.board_size, deterministic_seed=settings.deterministic_mode and 0 or None
+                )
+            except engine.InvalidMove:
+                raise_http("capacity_exceeded", {"retry_after": 5})
 
         player_board = _blank_board(settings.board_size)
         agent_board = _blank_board(settings.board_size)
@@ -92,22 +94,21 @@ def get_router(app: FastAPI, settings: Settings, loader: ModelLoader) -> APIRout
 
         if not loader.ready:
             raise_http("model_not_ready")
-        try:
-            player_result = engine.apply_player_move(session, (payload.x, payload.y))
-        except engine.InvalidMove as exc:
-            raise_http(str(exc))
-        except engine.GameFinished:
-            raise_http("game_finished")
+        with obs.span("game.move", {"game_id": session.game_id}):
+            try:
+                player_result = engine.apply_player_move(session, (payload.x, payload.y))
+            except engine.InvalidMove as exc:
+                raise_http(str(exc))
+            except engine.GameFinished:
+                raise_http("game_finished")
 
-        # Agent move (stub/deterministic)
-        try:
-            loader.assert_ready()
-            agent_coord = agent_adapter.next_move(session)
-            agent_result = engine.apply_agent_move(session, agent_coord)
-        except Exception:
-            raise_http("model_not_ready")
-        except engine.GameFinished:
-            pass
+            # Agent move (stub/deterministic)
+            try:
+                loader.assert_ready()
+                agent_coord = agent_adapter.next_move(session)
+                agent_result = engine.apply_agent_move(session, agent_coord)
+            except Exception:
+                raise_http("model_not_ready")
 
         response = MoveResponse(
             player_result=MoveResult(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn==0.29.0
 pytest==8.1.1
 httpx==0.27.0
 pytest-cov==4.1.0
+opentelemetry-api==1.26.0
+opentelemetry-sdk==1.26.0


### PR DESCRIPTION
## Summary
- add opentelemetry scaffold (tracer/meter) and span wrappers for start/move
- gate routes on model readiness; keep existing health and rate limit guards
- add otel deps to requirements

## Testing
- pytest
