### PR TITLE
TASK-011: CI wiring and container placeholders

### DIFF
--- a/CODE_MAP.md
+++ b/CODE_MAP.md
@@ -17,14 +17,27 @@
 - `app/`: FastAPI scaffold and configuration.
   - `config.py`: environment/config parsing and validation (paths, devices, limits).
   - `main.py`: FastAPI app factory and uvicorn runner.
-- `app/engine.py`: game session model, ship placement (deterministic-capable), move adjudication, in-memory session store.
+  - `engine.py`: game session model, ship placement (deterministic-capable), move adjudication, in-memory session store.
+  - `agent.py`: deterministic-capable agent stub.
+  - `errors.py`: structured error helpers.
+  - `health.py`: readiness hash/path checks.
+  - `rate_limit.py`: simple token bucket guard.
+  - `routes.py`: gameplay routes and health endpoints; readiness/rate limiting.
+  - `model_loader.py`: model hash/path readiness validation.
+  - `obs.py`: observability scaffold (spans/metrics placeholders).
 - `tests/`: Python tests.
   - `test_config.py`: settings/env validation and app smoke test.
   - `test_engine.py`: game engine/session tests (determinism, validation, outcomes).
-- `requirements.txt`: Python dependencies (fastapi, uvicorn, pytest).
+  - `test_health.py`: health/readiness tests.
+  - `test_rate_limit.py`: rate-limit guard tests.
+  - `test_agent.py`: deterministic agent tests.
+- `requirements.txt`: Python dependencies (fastapi, uvicorn, pytest, mypy, otel).
+- `docker-compose.yml`: local backend/frontend composition; healthcheck wiring.
+- `Dockerfile.backend`: backend container (FastAPI).
+- `Dockerfile.frontend`: placeholder frontend container (update when scaffolded).
+- `load_tests/k6_load.js`: k6 load test stub for start/move endpoints.
 
 ## Planned Additions
-- Backend gameplay modules: game engine, session store, agent adapter, API routes.
 - Frontend: React/Vite app, components, API client, tests.
 - Training: RL training pipeline scripts and artifacts.
 

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app /app/app
+EXPOSE 8000
+ENV MODEL_PATH=/app/model.bin \
+    MODEL_VERSION=v0.0.1 \
+    MODEL_HASH=stub \
+    MODEL_DEVICE=cpu \
+    BOARD_SIZE=10 \
+    LOG_LEVEL=info \
+    OBSERVABILITY_ENABLED=true \
+    DETERMINISTIC_MODE=true
+
+CMD ["uvicorn", "app.main:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,11 @@
+# Placeholder frontend Dockerfile; to be updated when frontend scaffold lands.
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json /app/
+RUN npm install || true
+COPY . /app
+# RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.9"
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    environment:
+      - MODEL_PATH=/app/model.bin
+      - MODEL_VERSION=v0.0.1
+      - MODEL_HASH=stub
+      - MODEL_DEVICE=cpu
+      - BOARD_SIZE=10
+      - LOG_LEVEL=info
+      - OBSERVABILITY_ENABLED=true
+      - DETERMINISTIC_MODE=true
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health/ready"]
+      interval: 10s
+      timeout: 2s
+      retries: 5
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "3000:80"


### PR DESCRIPTION
## Summary
- add backend/frontend Dockerfiles and docker-compose with readiness/liveness healthcheck for backend
- keep frontend Dockerfile as placeholder until scaffold exists
- update CODE_MAP with current modules and load test stub

## Testing
- docs/config only (no code changes)
